### PR TITLE
Add libp2p client and daemon packages for ai-torrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# ai-torrent
+
+Ce projet contient deux packages Node.js utilisant [libp2p](https://libp2p.io/) pour effectuer des requêtes d'inférence distribuées.
+
+## Packages
+
+- `client/` : programme CLI permettant de découvrir un noeud proposant un modèle d'IA via la DHT et d'envoyer une requête JSON sur le protocole `/ai-torrent/1/generate`.
+- `node/` : démon qui annonce sa capacité dans la DHT, relaye les requêtes vers une instance locale d'Ollama et renvoie les réponses en NDJSON.
+
+## Prérequis
+
+- Node.js ≥ 20
+
+## Démarrage rapide
+
+```bash
+# depuis la racine du repo
+# installation des dépendances
+npm install --prefix client
+npm install --prefix node
+
+# lancement du démon
+npm run start --prefix node
+
+# envoi d'une requête
+npm run ask --prefix client -- "Bonjour, qui es-tu ?"
+```
+
+Le démon doit avoir accès à une instance locale d'[Ollama](https://github.com/ollama/ollama) accessible sur `http://127.0.0.1:11434`.

--- a/client/cli.js
+++ b/client/cli.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { createLibp2p } from 'libp2p'
+import { noise } from '@chainsafe/libp2p-noise'
+import { webSockets } from '@libp2p/websockets'
+import { webrtc } from '@libp2p/webrtc'
+import { mplex } from '@libp2p/mplex'
+import { kadDHT } from '@libp2p/kad-dht'
+
+const prompt = process.argv.slice(2).join(' ')
+const params = {}
+
+const libp2p = await createLibp2p({
+  transports: [webSockets(), webrtc()],
+  streamMuxers: [mplex()],
+  connectionEncryption: [noise()],
+  dht: kadDHT()
+})
+
+await libp2p.start()
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+const key = encoder.encode('ait:cap:mistral-q4')
+const value = await libp2p.contentRouting.get(key)
+const addr = decoder.decode(value)
+
+const { stream } = await libp2p.dialProtocol(addr, '/ai-torrent/1/generate')
+
+await stream.sink((async function* () {
+  yield encoder.encode(JSON.stringify({ prompt, params }) + '\n')
+})())
+
+let buffer = ''
+for await (const chunk of stream.source) {
+  buffer += decoder.decode(chunk)
+  let index
+  while ((index = buffer.indexOf('\n')) !== -1) {
+    const line = buffer.slice(0, index)
+    buffer = buffer.slice(index + 1)
+    if (line.trim()) process.stdout.write(line + '\n')
+  }
+}
+
+await libp2p.stop()

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ai-torrent-client",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "ask": "node cli.js"
+  },
+  "dependencies": {
+    "libp2p": "*",
+    "@chainsafe/libp2p-noise": "*",
+    "@libp2p/kad-dht": "*",
+    "@libp2p/webrtc": "*",
+    "@libp2p/websockets": "*",
+    "@libp2p/mplex": "*"
+  }
+}

--- a/node/config.yaml
+++ b/node/config.yaml
@@ -1,0 +1,3 @@
+model: mistral
+maxConcurrent: 1
+announceKey: ait:cap:mistral-q4

--- a/node/daemon.js
+++ b/node/daemon.js
@@ -1,0 +1,64 @@
+import { createLibp2p } from 'libp2p'
+import { noise } from '@chainsafe/libp2p-noise'
+import { webSockets } from '@libp2p/websockets'
+import { webrtc } from '@libp2p/webrtc'
+import { mplex } from '@libp2p/mplex'
+import { kadDHT } from '@libp2p/kad-dht'
+import fs from 'node:fs/promises'
+import { parse } from 'yaml'
+import { generate } from './inference.js'
+
+const configText = await fs.readFile(new URL('./config.yaml', import.meta.url), 'utf8')
+const config = parse(configText)
+
+const libp2p = await createLibp2p({
+  transports: [webSockets(), webrtc()],
+  streamMuxers: [mplex()],
+  connectionEncryption: [noise()],
+  dht: kadDHT()
+})
+
+await libp2p.start()
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+const announceKey = config.announceKey || 'ait:cap:mistral-q4'
+const addr = libp2p.getMultiaddrs()[0]?.toString() || ''
+await libp2p.contentRouting.put(encoder.encode(announceKey), encoder.encode(addr))
+console.log(`announced ${announceKey} at ${addr}`)
+
+let active = 0
+const limit = config.maxConcurrent || 1
+
+libp2p.handle('/ai-torrent/1/generate', async ({ stream }) => {
+  if (active >= limit) {
+    await stream.sink((async function* () {
+      yield encoder.encode(JSON.stringify({ error: 'Too many requests' }) + '\n')
+    })())
+    return
+  }
+  active++
+  try {
+    let data = ''
+    for await (const chunk of stream.source) {
+      data += decoder.decode(chunk)
+      if (data.includes('\n')) break
+    }
+    const req = JSON.parse(data.trim())
+    const { prompt, params = {} } = req
+
+    await stream.sink((async function* () {
+      for await (const line of generate(prompt, params, config.model)) {
+        yield encoder.encode(line + '\n')
+      }
+    })())
+  } catch (err) {
+    await stream.sink((async function* () {
+      yield encoder.encode(JSON.stringify({ error: err.message }) + '\n')
+    })())
+  } finally {
+    active--
+  }
+})
+
+console.log('daemon running')

--- a/node/inference.js
+++ b/node/inference.js
@@ -1,0 +1,25 @@
+const apiURL = 'http://127.0.0.1:11434/api/generate'
+
+export async function* generate(prompt, params, model) {
+  const res = await fetch(apiURL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, prompt, stream: true, ...params })
+  })
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    let index
+    while ((index = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, index)
+      buffer = buffer.slice(index + 1)
+      if (line.trim()) yield line
+    }
+  }
+  if (buffer.trim()) yield buffer
+}

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ai-torrent-node",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "start": "node daemon.js"
+  },
+  "dependencies": {
+    "libp2p": "*",
+    "@chainsafe/libp2p-noise": "*",
+    "@libp2p/kad-dht": "*",
+    "@libp2p/webrtc": "*",
+    "@libp2p/websockets": "*",
+    "@libp2p/mplex": "*",
+    "yaml": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- add CLI client to discover peers via DHT and query `/ai-torrent/1/generate`
- add daemon exposing inference protocol and relaying to local Ollama
- document setup and usage

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*
- `npm test --prefix node` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c080dc8e208332b85c7b29afdf9f2c