### PR TITLE
fix: correct WebRTC import name

### DIFF
--- a/client/cli.js
+++ b/client/cli.js
@@ -2,7 +2,7 @@
 import { createLibp2p } from 'libp2p'
 import { noise } from '@chainsafe/libp2p-noise'
 import { webSockets } from '@libp2p/websockets'
-import { webrtc } from '@libp2p/webrtc'
+import { webRTC } from '@libp2p/webrtc'
 import { mplex } from '@libp2p/mplex'
 import { kadDHT } from '@libp2p/kad-dht'
 
@@ -10,7 +10,7 @@ const prompt = process.argv.slice(2).join(' ')
 const params = {}
 
 const libp2p = await createLibp2p({
-  transports: [webSockets(), webrtc()],
+  transports: [webSockets(), webRTC()],
   streamMuxers: [mplex()],
   connectionEncryption: [noise()],
   dht: kadDHT()

--- a/node/daemon.js
+++ b/node/daemon.js
@@ -1,7 +1,7 @@
 import { createLibp2p } from 'libp2p'
 import { noise } from '@chainsafe/libp2p-noise'
 import { webSockets } from '@libp2p/websockets'
-import { webrtc } from '@libp2p/webrtc'
+import { webRTC } from '@libp2p/webrtc'
 import { mplex } from '@libp2p/mplex'
 import { kadDHT } from '@libp2p/kad-dht'
 import fs from 'node:fs/promises'
@@ -12,7 +12,7 @@ const configText = await fs.readFile(new URL('./config.yaml', import.meta.url), 
 const config = parse(configText)
 
 const libp2p = await createLibp2p({
-  transports: [webSockets(), webrtc()],
+  transports: [webSockets(), webRTC()],
   streamMuxers: [mplex()],
   connectionEncryption: [noise()],
   dht: kadDHT()


### PR DESCRIPTION
## Summary
- use correct `webRTC` export from `@libp2p/webrtc`
- update transports configuration to call `webRTC()`

## Testing
- `cd node && npm test` *(fails: Missing script "test")*
- `cd client && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0840cc830833292abc2ca03b1cd85