### PR TITLE
Add connection and request logging to daemon

### DIFF
--- a/node/daemon.js
+++ b/node/daemon.js
@@ -34,6 +34,13 @@ const libp2p = await createLibp2p({
 
 await libp2p.start()
 
+libp2p.addEventListener('peer:connect', e => {
+  console.log('peer connected:', e.detail.remotePeer.toString())
+})
+libp2p.addEventListener('peer:disconnect', e => {
+  console.log('peer disconnected:', e.detail.remotePeer.toString())
+})
+
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 const announceKey = config.announceKey || 'ait:cap:mistral-q4'
@@ -50,7 +57,8 @@ try {
 let active = 0
 const limit = config.maxConcurrent || 1
 
-libp2p.handle('/ai-torrent/1/generate', async ({ stream }) => {
+libp2p.handle('/ai-torrent/1/generate', async ({ stream, connection }) => {
+  console.log('incoming generate request from', connection.remotePeer.toString())
   if (active >= limit) {
     await stream.sink((async function* () {
       yield encoder.encode(JSON.stringify({ error: 'Too many requests' }) + '\n')


### PR DESCRIPTION
## Summary
- log peer connect/disconnect events after libp2p startup
- log incoming generate requests with remote peer info

## Testing
- `npm test` *(fails: Missing script "test")*
- `node daemon.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0a063997c8332a08c5566b0e75c31