### PR TITLE
Use direct stream assignment when dialing provider

### DIFF
--- a/client/cli.js
+++ b/client/cli.js
@@ -48,12 +48,12 @@ if (!addr) {
 
 let stream
 try {
-  ({ stream } = await libp2p.dialProtocol(multiaddr(addr), '/ai-torrent/1/generate'))
+  stream = await libp2p.dialProtocol(multiaddr(addr), '/ai-torrent/1/generate')
 } catch (err) {
   console.error('Failed to connect to provider:', err)
   process.exit(1)
 }
-if (stream == null) {
+if (!stream) {
   console.error('No stream returned from provider')
   process.exit(1)
 }


### PR DESCRIPTION
## Summary
- Avoid destructuring the stream returned by libp2p.dialProtocol and assign directly.
- Replace null check with simple falsy check for the stream.

## Testing
- `node client/cli.js` *(fails: Failed to resolve provider address)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a11a6c388332ae45056742876203