### PR TITLE
feat: allow configuring daemon port

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Ce projet contient deux packages Node.js utilisant [libp2p](https://libp2p.io/) 
 
 - Node.js ≥ 20
 
+## Variables d'environnement
+
+- `PORT` : port d'écoute du démon. S'il n'est pas défini, un port libre aléatoire est choisi. Le client utilise également cette valeur pour se connecter au démon local lorsque `AI_TORRENT_ADDR` n'est pas fournie.
+
 ## Démarrage rapide
 
 ```bash

--- a/client/cli.js
+++ b/client/cli.js
@@ -41,6 +41,13 @@ const decoder = new TextDecoder()
 const key = encoder.encode('ait:cap:mistral-q4')
 
 let addr = process.env.AI_TORRENT_ADDR
+if (!addr && process.env.PORT) {
+  try {
+    const fileAddr = readFileSync(new URL('./daemon.addr', import.meta.url), 'utf8').trim()
+    const peerId = fileAddr.split('/p2p/')[1]
+    if (peerId) addr = `/ip4/127.0.0.1/tcp/${process.env.PORT}/ws/p2p/${peerId}`
+  } catch {}
+}
 if (!addr) {
   try {
     addr = readFileSync(new URL('./daemon.addr', import.meta.url), 'utf8').trim()

--- a/node/daemon.js
+++ b/node/daemon.js
@@ -22,10 +22,11 @@ const configText = await fsp.readFile(new URL('./config.yaml', import.meta.url),
 const config = parse(configText)
 
 const bootstrappers = [process.env.BOOTSTRAP_ADDR].filter(Boolean)
+const port = process.env.PORT || 0
 
 const libp2p = await createLibp2p({
   addresses: {
-    listen: ['/ip4/0.0.0.0/tcp/0/ws']
+    listen: [`/ip4/0.0.0.0/tcp/${port}/ws`]
   },
   transports: [webSockets()],
   streamMuxers: [mplex()],


### PR DESCRIPTION
## Summary
- allow daemon to listen on a specific port via `PORT`
- default client address to localhost using `PORT` when no address is supplied
- document the `PORT` environment variable

## Testing
- `npm test --prefix client` *(fails: Missing script: "test")*
- `npm test --prefix node` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0a50a6f088332a3bf0e7b4f9cbc6c