### PR TITLE
feat: add discovery flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ce projet contient deux packages Node.js utilisant [libp2p](https://libp2p.io/) 
 ## Variables d'environnement
 
 - `PORT` : port d'écoute du démon. S'il n'est pas défini, un port libre aléatoire est choisi. Le client utilise également cette valeur pour se connecter au démon local lorsque `AI_TORRENT_ADDR` n'est pas fournie.
+- `AI_TORRENT_ADDR` : adresse explicite du fournisseur. Ignorée si l'option `--discover` est utilisée.
 
 ## Démarrage rapide
 
@@ -26,8 +27,10 @@ npm install --prefix node
 # lancement du démon
 npm run start --prefix node
 
-# envoi d'une requête
-npm run ask --prefix client -- "Bonjour, qui es-tu ?"
+# envoi d'une requête (découverte automatique)
+npm run ask --prefix client -- --discover "Bonjour, qui es-tu ?"
 ```
 
 Le démon doit avoir accès à une instance locale d'[Ollama](https://github.com/ollama/ollama) accessible sur `http://127.0.0.1:11434`.
+
+L'option `--discover` force le client à ignorer `AI_TORRENT_ADDR` et à découvrir l'adresse du fournisseur via le fichier `daemon.addr` ou la DHT.

--- a/client/cli.js
+++ b/client/cli.js
@@ -19,7 +19,11 @@ if (typeof Promise.withResolvers !== 'function') {
 }
 
 
-const prompt = process.argv.slice(2).join(' ')
+const args = process.argv.slice(2)
+const discoverIndex = args.indexOf('--discover')
+const discover = discoverIndex !== -1
+if (discover) args.splice(discoverIndex, 1)
+const prompt = args.join(' ')
 const params = {}
 
 const bootstrappers = [process.env.BOOTSTRAP_ADDR].filter(Boolean)
@@ -41,7 +45,8 @@ const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 const key = encoder.encode('ait:cap:mistral-q4')
 
-let addr = process.env.AI_TORRENT_ADDR
+let addr
+if (!discover) addr = process.env.AI_TORRENT_ADDR
 if (!addr && process.env.PORT) {
   try {
     const fileAddr = readFileSync(new URL('./daemon.addr', import.meta.url), 'utf8').trim()


### PR DESCRIPTION
## Summary
- add --discover flag to CLI to resolve provider address automatically
- document the new flag and env var usage

## Testing
- `npm test --prefix client` *(fails: Missing script: "test")*
- `npm test --prefix node` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0adc179e48332b8393016708e32c0