### PR TITLE
Allow static daemon port via config and document PORT usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Ce projet contient deux packages Node.js utilisant [libp2p](https://libp2p.io/) 
 
 ## Variables d'environnement
 
-- `PORT` : port d'écoute du démon. S'il n'est pas défini, un port libre aléatoire est choisi. Le client utilise également cette valeur pour se connecter au démon local lorsque `AI_TORRENT_ADDR` n'est pas fournie.
+- `PORT` : port d'écoute du démon. Par défaut, le démon utilise le port configuré dans `node/config.yaml` (55781). Pour choisir un port stable, définissez cette variable avant de lancer le démon, par exemple : `PORT=60000 npm run start --prefix node`. Le client utilise également cette valeur pour se connecter au démon local lorsque `AI_TORRENT_ADDR` n'est pas fournie.
 - `AI_TORRENT_ADDR` : adresse explicite du fournisseur. Ignorée si l'option `--discover` est utilisée.
 
 ## Démarrage rapide

--- a/node/config.yaml
+++ b/node/config.yaml
@@ -1,3 +1,4 @@
 model: mistral
 maxConcurrent: 1
 announceKey: ait:cap:mistral-q4
+port: 55781

--- a/node/daemon.js
+++ b/node/daemon.js
@@ -22,7 +22,7 @@ const configText = await fsp.readFile(new URL('./config.yaml', import.meta.url),
 const config = parse(configText)
 
 const bootstrappers = [process.env.BOOTSTRAP_ADDR].filter(Boolean)
-const port = process.env.PORT || 0
+const port = process.env.PORT || config.port || 55781
 
 const libp2p = await createLibp2p({
   addresses: {


### PR DESCRIPTION
## Summary
- Read daemon port from config file with default 55781, overridable via PORT
- Add port field to node/config.yaml
- Document how to set PORT to run daemon on stable port

## Testing
- `npm test --prefix node` (fails: Missing script "test")
- `npm test --prefix client` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c0bb3fea0c83328efedbfff25f2e21