### PR TITLE
Fix peer event detail usage

### DIFF
--- a/node/daemon.js
+++ b/node/daemon.js
@@ -41,10 +41,10 @@ const libp2p = await createLibp2p({
 await libp2p.start()
 
 libp2p.addEventListener('peer:connect', e => {
-  console.log('peer connected:', e.detail.remotePeer.toString())
+  console.log('peer connected:', e.detail.toString())
 })
 libp2p.addEventListener('peer:disconnect', e => {
-  console.log('peer disconnected:', e.detail.remotePeer.toString())
+  console.log('peer disconnected:', e.detail.toString())
 })
 
 const encoder = new TextEncoder()


### PR DESCRIPTION
## Summary
- Fix daemon peer event logging to use event detail directly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@libp2p%2fbootstrap)*
- `node daemon.js` *(fails: Cannot find package 'libp2p' imported from /workspace/MVP-P2P-chatbot-client-node-/node/daemon.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bbc3cdb08332b7b8ecdd80e31dfe