### PR TITLE
fix: decode stream chunks as Uint8Array

### DIFF
--- a/client/cli.js
+++ b/client/cli.js
@@ -97,7 +97,8 @@ await stream.sink((async function* () {
 
 let buffer = ''
 for await (const chunk of stream.source) {
-  buffer += decoder.decode(chunk)
+  const data = chunk.subarray ? chunk.subarray() : chunk
+  buffer += decoder.decode(data)
   let index
   while ((index = buffer.indexOf('\n')) !== -1) {
     const line = buffer.slice(0, index)


### PR DESCRIPTION
## Summary
- ensure chunks from libp2p stream are converted to Uint8Array before decoding

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*
- `node -e "(async () => { const decoder = new TextDecoder(); const stream = { source: (async function*(){ yield Buffer.from('first\\nsecond\\n'); })() }; let buffer=''; for await (const chunk of stream.source) { const data = chunk.subarray ? chunk.subarray() : chunk; buffer += decoder.decode(data); let index; while((index = buffer.indexOf('\\n')) !== -1) { const line = buffer.slice(0,index); buffer = buffer.slice(index+1); if (line.trim()) process.stdout.write(line + '\\n'); } } })()"`


------
https://chatgpt.com/codex/tasks/task_e_68c0bd2c897c8332a02714a51926ed58