### PR TITLE
Ensure stream chunks are Uint8Array before decoding

### DIFF
--- a/client/cli.js
+++ b/client/cli.js
@@ -97,7 +97,7 @@ await stream.sink((async function* () {
 
 let buffer = ''
 for await (const chunk of stream.source) {
-  const data = chunk.subarray ? chunk.subarray() : chunk
+  const data = chunk.subarray ? chunk.subarray() : Uint8Array.from(chunk)
   buffer += decoder.decode(data)
   let index
   while ((index = buffer.indexOf('\n')) !== -1) {


### PR DESCRIPTION
## Summary
- Normalize provider stream chunks to `Uint8Array` before decoding to text.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden)
- `npm run ask -- --discover "Bonjour, qui es-tu ?"` *(fails: Cannot find package 'libp2p')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c07896b883328d8bda12efc70ff7