### PR TITLE
Fix chunk decoding in generate handler

### DIFF
--- a/node/daemon.js
+++ b/node/daemon.js
@@ -80,7 +80,8 @@ libp2p.handle('/ai-torrent/1/generate', async ({ stream, connection }) => {
   try {
     let data = ''
     for await (const chunk of stream.source) {
-      data += decoder.decode(chunk)
+      const dataChunk = chunk.subarray ? chunk.subarray() : Uint8Array.from(chunk)
+      data += decoder.decode(dataChunk)
       if (data.includes('\n')) break
     }
     const req = JSON.parse(data.trim())


### PR DESCRIPTION
## Summary
- handle Node.js stream chunks before decoding to ensure TextDecoder receives a Uint8Array

## Testing
- `npm test --prefix node` *(fails: Missing script "test")*
- `node node/daemon.js` *(fails: Cannot find package 'libp2p')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c0fae44c8332aa432ceff395a0ee