### PR TITLE
feat: add interactive CLI prompt loop

### DIFF
--- a/client/cli.js
+++ b/client/cli.js
@@ -9,6 +9,8 @@ import { bootstrap } from '@libp2p/bootstrap'
 import { multiaddr } from '@multiformats/multiaddr'
 import { readFileSync } from 'node:fs'
 import { ConnectionFailedError } from '@libp2p/interface'
+import { createInterface } from 'readline/promises'
+import { stdin as input, stdout as output } from 'node:process'
 
 if (typeof Promise.withResolvers !== 'function') {
   Promise.withResolvers = () => {
@@ -23,7 +25,6 @@ const args = process.argv.slice(2)
 const discoverIndex = args.indexOf('--discover')
 const discover = discoverIndex !== -1
 if (discover) args.splice(discoverIndex, 1)
-const prompt = args.join(' ')
 const params = {}
 
 const bootstrappers = [process.env.BOOTSTRAP_ADDR].filter(Boolean)
@@ -40,6 +41,8 @@ const libp2p = await createLibp2p({
 })
 
 await libp2p.start()
+
+const rl = createInterface({ input, output })
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
@@ -71,50 +74,60 @@ if (!addr) {
   }
 }
 
-let stream
-try {
-  console.log(`Connecting to provider at ${addr}`)
-  stream = await libp2p.dialProtocol(multiaddr(addr), '/ai-torrent/1/generate')
-} catch (err) {
-  if (err instanceof ConnectionFailedError) {
-    const msg = err.cause?.message ?? err.message
-    console.error(`Failed to connect to provider at ${addr}: ${msg}`)
-    console.error('Hint: AI_TORRENT_ADDR may be outdated or the daemon may not be running.')
-  } else {
-    console.error(`Failed to connect to provider at ${addr}:`, err)
-    console.error('Hint: AI_TORRENT_ADDR may be outdated or the daemon may not be running.')
+async function sendPrompt (prompt) {
+  let stream
+  try {
+    console.log(`Connecting to provider at ${addr}`)
+    stream = await libp2p.dialProtocol(multiaddr(addr), '/ai-torrent/1/generate')
+  } catch (err) {
+    if (err instanceof ConnectionFailedError) {
+      const msg = err.cause?.message ?? err.message
+      console.error(`Failed to connect to provider at ${addr}: ${msg}`)
+      console.error('Hint: AI_TORRENT_ADDR may be outdated or the daemon may not be running.')
+    } else {
+      console.error(`Failed to connect to provider at ${addr}:`, err)
+      console.error('Hint: AI_TORRENT_ADDR may be outdated or the daemon may not be running.')
+    }
+    return
   }
-  process.exit(1)
-}
-if (!stream) {
-  console.error('No stream returned from provider')
-  process.exit(1)
+  if (!stream) {
+    console.error('No stream returned from provider')
+    return
+  }
+
+  await stream.sink((async function * () {
+    yield encoder.encode(JSON.stringify({ prompt, params }) + '\n')
+  })())
+
+  let buffer = ''
+  outer: for await (const chunk of stream.source) {
+    const data = chunk.subarray ? chunk.subarray() : Uint8Array.from(chunk)
+    buffer += decoder.decode(data)
+    let index
+    while ((index = buffer.indexOf('\n')) !== -1) {
+      const line = buffer.slice(0, index)
+      buffer = buffer.slice(index + 1)
+      if (!line.trim()) continue
+      const msg = JSON.parse(line)
+      process.stdout.write(msg.response || '')
+      if (msg.error) {
+        console.error(msg.error)
+        break outer
+      }
+      if (msg.done) {
+        process.stdout.write('\n')
+        break outer
+      }
+    }
+  }
 }
 
-await stream.sink((async function* () {
-  yield encoder.encode(JSON.stringify({ prompt, params }) + '\n')
-})())
-
-let buffer = ''
-outer: for await (const chunk of stream.source) {
-  const data = chunk.subarray ? chunk.subarray() : Uint8Array.from(chunk)
-  buffer += decoder.decode(data)
-  let index
-  while ((index = buffer.indexOf('\n')) !== -1) {
-    const line = buffer.slice(0, index)
-    buffer = buffer.slice(index + 1)
-    if (!line.trim()) continue
-    const msg = JSON.parse(line)
-    process.stdout.write(msg.response || '')
-    if (msg.error) {
-      console.error(msg.error)
-      break outer
-    }
-    if (msg.done) {
-      process.stdout.write('\n')
-      break outer
-    }
-  }
+while (true) {
+  const prompt = await rl.question('> ')
+  const trimmed = prompt.trim().toLowerCase()
+  if (trimmed === 'exit' || trimmed === 'quit') break
+  await sendPrompt(prompt)
 }
 
 await libp2p.stop()
+rl.close()


### PR DESCRIPTION
## Summary
- add readline-based CLI for interactive sessions
- wrap prompt/response handling in `sendPrompt`
- keep libp2p node running across multiple questions

## Testing
- `npm run ask` *(fails: Cannot find package 'libp2p')*


------
https://chatgpt.com/codex/tasks/task_e_68c0c39350ec833281c87a17a07ac569