### PR TITLE
feat: announce reward address

### DIFF
--- a/node/config.yaml
+++ b/node/config.yaml
@@ -2,3 +2,4 @@ model: mistral
 maxConcurrent: 1
 announceKey: ait:cap:mistral-q4
 port: 55781
+rewardAddress: "<0x...>"

--- a/node/daemon.js
+++ b/node/daemon.js
@@ -51,15 +51,19 @@ const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 const announceKey = config.announceKey || 'ait:cap:mistral-q4'
 const addr = libp2p.getMultiaddrs()[0]?.toString() || ''
+const rewardAddress = config.rewardAddress || ''
+const announcement = JSON.stringify({ addr, rewardAddress })
 
 console.log(`listening on ${addr}`)
 try {
-  writeFileSync(new URL('../client/daemon.addr', import.meta.url), addr)
+  const fileData = [addr]
+  if (rewardAddress) fileData.push(rewardAddress)
+  writeFileSync(new URL('../client/daemon.addr', import.meta.url), fileData.join('\n'))
 } catch (err) {
   console.warn('Failed to write address file:', err)
 }
 try {
-  await libp2p.contentRouting.put(encoder.encode(announceKey), encoder.encode(addr))
+  await libp2p.contentRouting.put(encoder.encode(announceKey), encoder.encode(announcement))
   console.log(`announced ${announceKey} at ${addr}`)
 } catch (err) {
   console.warn('Failed to announce address:', err)


### PR DESCRIPTION
## Summary
- add rewardAddress field to node configuration
- announce JSON including rewardAddress and multiaddr
- save reward address beside multiaddr for local testing

## Testing
- `npm test` *(fails: sh: 1: hardhat: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e6e183d083328223cd117b850ff7