### PR TITLE
feat: add web3 reward system

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,8 @@
         "@libp2p/mplex": "*",
         "@libp2p/websockets": "*",
         "@libp2p/ping": "*",
-        "libp2p": "*"
+        "libp2p": "*",
+        "web3": "*"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@libp2p/websockets": "*",
     "@libp2p/bootstrap": "*",
     "@libp2p/ping": "*",
-    "libp2p": "*"
+    "libp2p": "*",
+    "web3": "*"
   }
 }


### PR DESCRIPTION
## Summary
- add web3 dependency for client
- initialize web3 and token contract, tracking requests per peer
- reward peers every tenth request

## Testing
- `npm test --prefix client` *(fails: Missing script: "test")*
- `npm test` *(fails: hardhat: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e7a1f8c083329bb76c85d3ec14f3